### PR TITLE
Add concurrency settings to CI, auto-assign, and release workflows

### DIFF
--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -7,6 +7,10 @@ on:
   pull_request:
     types: [opened, reopened]
 
+concurrency:
+  group: auto-assign-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   auto-assign:
     name: Auto Assign

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,10 @@ on:
   pull_request:
     branches: ["*"]
 
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   install-and-check:
     name: Install and Check

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,10 @@ on:
   push:
     tags: ["*"]
 
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   release:
     name: Release


### PR DESCRIPTION
Introduce concurrency settings to ensure that only one instance of each workflow runs at a time, improving efficiency and resource management.