### PR TITLE
fix: remove hardcoded pnpm version from CI and release workflows, (it is already included in the `package.json`)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 10.11.1
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,8 +25,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 10.11.1
 
       - name: Setup Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
This pull request makes small updates to the CI and release workflows by removing the explicit version specification for `pnpm`. 

Changes to workflows:

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL25-L26): Removed the `version: 10.11.1` configuration from the `pnpm` setup step.
* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L28-L29): Removed the `version: 10.11.1` configuration from the `pnpm` setup step.n