### PR TITLE
fix: update pnpm version to 10.12.1 in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "turbo": "^2.5.4",
     "typescript": "5.8.3"
   },
-  "packageManager": "pnpm@10.11.1",
+  "packageManager": "pnpm@10.12.1",
   "engines": {
     "node": ">=18"
   }


### PR DESCRIPTION
This pull request includes a small update to the `package.json` file, upgrading the `pnpm` package manager version from `10.11.1` to `10.12.1`.