### PR TITLE
fix: update version and author URL in package.json

### DIFF
--- a/packages/typescript-config/package.json
+++ b/packages/typescript-config/package.json
@@ -1,11 +1,11 @@
 {
   "name": "@magnidev/typescript-config",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "license": "ISC",
   "description": "TypeScript configuration files for the Magni Development monorepo.",
   "author": {
     "name": "fermeridamagni <Magni Development>",
-    "url": "https://magnideveloper.com"
+    "url": "https://magni.dev"
   },
   "repository": {
     "type": "git",
@@ -20,7 +20,7 @@
   "bugs": {
     "url": "https://github.com/magnidev/magnidev-monorepo/issues"
   },
-  "homepage": "https://magnideveloper.com/en/docs/developers/packages/typescript-config/getting-started/introduction",
+  "homepage": "https://magni.dev/en/docs/developers/packages/typescript-config/getting-started/introduction",
   "exports": {
     "./node-base": "./src/tsconfig.node-base.json",
     "./node-library": "./src/tsconfig.node-library.json"


### PR DESCRIPTION
This pull request includes minor updates to the `package.json` file for the `@magnidev/typescript-config` package. The changes primarily involve version updates and URL modifications to reflect the new domain.

Version update:

* Updated the package version from `0.2.0` to `0.2.1`.

URL modifications:

* Changed the author's URL from `https://magnideveloper.com` to `https://magni.dev`.
* Updated the homepage URL to use the new domain, changing from `https://magnideveloper.com/en/docs/developers/packages/typescript-config/getting-started/introduction` to `https://magni.dev/en/docs/developers/packages/typescript-config/getting-started/introduction`.