### PR TITLE
fix: update author URL and homepage in package.json, bump tailwindcss…

### DIFF
--- a/packages/frontend-utils/package.json
+++ b/packages/frontend-utils/package.json
@@ -5,7 +5,7 @@
   "description": "Utility functions for frontend development",
   "author": {
     "name": "fermeridamagni <Magni Development>",
-    "url": "https://www.magnideveloper.com"
+    "url": "https://www.magni.dev"
   },
   "repository": {
     "url": "git+https://github.com/magnidev/magnidev-monorepo.git",
@@ -16,7 +16,7 @@
   "bugs": {
     "url": "https://github.com/magnidev/magnidev-monorepo/issues"
   },
-  "homepage": "https://magnideveloper.com/en/docs/developers/packages/frontend-utils/getting-started/introduction",
+  "homepage": "https://www.magni.dev/en/docs/developers/packages/frontend-utils/getting-started/introduction",
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "dev": "ts-node src/index.ts"
@@ -38,11 +38,11 @@
     "registry": "https://registry.npmjs.org/"
   },
   "peerDependencies": {
-    "tailwindcss": "4.1.8"
+    "tailwindcss": "4.1.10"
   },
   "dependencies": {
     "clsx": "^2.1.1",
-    "tailwind-merge": "^3.3.0"
+    "tailwind-merge": "^3.3.1"
   },
   "devDependencies": {
     "@magnidev/typescript-config": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,11 +42,11 @@ importers:
         specifier: ^2.1.1
         version: 2.1.1
       tailwind-merge:
-        specifier: ^3.3.0
-        version: 3.3.0
+        specifier: ^3.3.1
+        version: 3.3.1
       tailwindcss:
-        specifier: 4.1.8
-        version: 4.1.8
+        specifier: 4.1.10
+        version: 4.1.10
     devDependencies:
       '@magnidev/typescript-config':
         specifier: workspace:*
@@ -1508,8 +1508,11 @@ packages:
     resolution: {integrity: sha512-+XZ+r1XGIJGeQk3VvXhT6xx/VpbHsRzsTkGgF6E5RX9TTXD0118l87puaEBZ566FhqblC6U0d4XnubznJDm30A==}
     engines: {node: ^14.18.0 || >=16.0.0}
 
-  tailwind-merge@3.3.0:
-    resolution: {integrity: sha512-fyW/pEfcQSiigd5SNn0nApUOxx0zB/dm6UDU/rEwc2c3sX2smWUNbapHv+QRqLGVp9GWX3THIa7MUGPo+YkDzQ==}
+  tailwind-merge@3.3.1:
+    resolution: {integrity: sha512-gBXpgUm/3rp1lMZZrM/w7D8GKqshif0zAymAhbCyIt8KMe+0v9DQ7cdYLR4FHH/cKpdTXb+A/tKKU3eolfsI+g==}
+
+  tailwindcss@4.1.10:
+    resolution: {integrity: sha512-P3nr6WkvKV/ONsTzj6Gb57sWPMX29EPNPopo7+FcpkQaNsrNpZ1pv8QmrYI2RqEKD7mlGqLnGovlcYnBK0IqUA==}
 
   tailwindcss@4.1.8:
     resolution: {integrity: sha512-kjeW8gjdxasbmFKpVGrGd5T4i40mV5J2Rasw48QARfYeQ8YS9x02ON9SFWax3Qf616rt4Cp3nVNIj6Hd1mP3og==}
@@ -3147,7 +3150,9 @@ snapshots:
     dependencies:
       '@pkgr/core': 0.2.4
 
-  tailwind-merge@3.3.0: {}
+  tailwind-merge@3.3.1: {}
+
+  tailwindcss@4.1.10: {}
 
   tailwindcss@4.1.8: {}
 


### PR DESCRIPTION
This pull request updates the `packages/frontend-utils` dependencies and metadata, as well as the corresponding entries in the `pnpm-lock.yaml` file. The most important changes include updating URLs in metadata fields, upgrading `tailwindcss` and `tailwind-merge` versions, and reflecting these updates in the lock file.

### Metadata updates:
* Updated the `author.url` and `homepage` fields in `packages/frontend-utils/package.json` to use the new domain `magni.dev`. [[1]](diffhunk://#diff-0b433ff5730002117abe787cd851191200d95a8160cb579d495c891182d64076L8-R8) [[2]](diffhunk://#diff-0b433ff5730002117abe787cd851191200d95a8160cb579d495c891182d64076L19-R19)

### Dependency updates:
* Upgraded `tailwindcss` from version `4.1.8` to `4.1.10` and `tailwind-merge` from version `3.3.0` to `3.3.1` in `packages/frontend-utils/package.json`.
* Updated the corresponding entries for `tailwindcss` and `tailwind-merge` in the `pnpm-lock.yaml` file under `importers`, `packages`, and `snapshots`. [[1]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL45-R49) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL1511-R1515) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL3150-R3155)… and tailwind-merge versions