### PR TITLE
refactor: streamline CI workflow by consolidating job steps and impro…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,45 +2,27 @@ name: CI
 
 on:
   push:
-    branches: ["*"]
-
+    branches:
+      - main # Run on pushes to the main branch
   pull_request:
-    branches: ["*"]
+    branches:
+      - main # Run on pull requests targeting the main branch
 
+# Automatically cancel in-progress actions on the same branch
 concurrency:
-  group: ci-${{ github.ref }}
-  cancel-in-progress: true
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
-  install-and-check:
-    name: Install and Check
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 22.x # Use the latest LTS version of Node.js
-          registry-url: https://registry.npmjs.org/
-          cache: "pnpm"
-
-      - name: Install dependencies
-        run: pnpm install
-
-      - name: Lint
-        run: pnpm lint
-
-      - name: Format check
-        run: pnpm format:check
-
-      - name: Build
-        run: pnpm build
-
-      - name: Test
-        run: pnpm test
+  scripts:
+    if: github.repository_owner == 'magnidev'
+    uses: magnidev/automation/.github/workflows/run.yml@main
+    secrets: inherit
+    with:
+      commands: >
+        [
+          "lint",
+          "format:check",
+          "build",
+          "test"
+        ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,10 @@ jobs:
     # This is intentional for internal use. Forks or external contributions will not execute this workflow.
     if: github.repository_owner == 'magnidev'
     uses: magnidev/automation/.github/workflows/run.yml@main # Reuse the run workflow from the magnidev/automation repository
-    secrets: "inherit" # Inherit secrets from the parent workflow
+    secrets:
+      BOT_APP_ID: ${{ secrets.BOT_APP_ID }}
+      BOT_PRIVATE_KEY: ${{ secrets.BOT_PRIVATE_KEY }}
+
     with:
       commands: >
         [

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: CI
+name: CI # Continuous Integration Workflow
 
 on:
   push:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ on:
 # Automatically cancel in-progress actions on the same branch
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }} # Cancel in-progress runs for branches other than main
 
 jobs:
   scripts:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   scripts:
     if: github.repository_owner == 'magnidev'
-    uses: magnidev/automation/.github/workflows/run.yml@main
+    uses: magnidev/automation/.github/workflows/run.yml@main # Reuse the run workflow from the magnidev/automation repository
     secrets: inherit
     with:
       commands: >

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: CI # Continuous Integration Workflow
+name: CI
 
 on:
   push:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,3 +30,4 @@ jobs:
           "build",
           "test"
         ]
+      # The 'commands' input specifies the commands to run in the CI workflow.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,9 +19,7 @@ jobs:
     # This is intentional for internal use. Forks or external contributions will not execute this workflow.
     if: github.repository_owner == 'magnidev'
     uses: magnidev/automation/.github/workflows/run.yml@main # Reuse the run workflow from the magnidev/automation repository
-    secrets:
-      BOT_APP_ID: ${{ secrets.BOT_APP_ID }}
-      BOT_PRIVATE_KEY: ${{ secrets.BOT_PRIVATE_KEY }}
+    secrets: "inherit" # Inherit secrets from the parent workflow
     with:
       commands: >
         [

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,9 @@ jobs:
   scripts:
     if: github.repository_owner == 'magnidev'
     uses: magnidev/automation/.github/workflows/run.yml@main # Reuse the run workflow from the magnidev/automation repository
-    secrets: inherit
+    secrets:
+      BOT_APP_ID: ${{ secrets.BOT_APP_ID }}
+      BOT_PRIVATE_KEY: ${{ secrets.BOT_PRIVATE_KEY }}
     with:
       commands: >
         [


### PR DESCRIPTION
This pull request updates the CI workflow configuration to streamline and simplify the process. The changes include limiting CI runs to the `main` branch, introducing a new concurrency group configuration, and replacing custom job definitions with reusable workflows.

### CI workflow updates:

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL5-R28): Modified the `push` and `pull_request` triggers to only run CI on the `main` branch.
* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL5-R28): Updated the concurrency group configuration to use a more specific identifier and prevent automatic cancellation for the `main` branch.
* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL5-R28): Replaced the previous job definitions with a reusable workflow (`magnidev/automation/.github/workflows/run.yml@main`) to simplify maintenance and execution.…ving branch targeting