### PR TITLE
fix: update auto-assign action to version 2

### DIFF
--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: "Auto-assign issue"
-        uses: pozil/auto-assign-issue@v1
+        uses: pozil/auto-assign-issue@v2
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           assignees: fermeridamagni

--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -8,22 +8,18 @@ on:
     types: [opened, reopened]
 
 concurrency:
-  group: auto-assign-${{ github.ref }}
+  group: auto-assign-${{ github.ref }} # Group runs by the current ref to avoid conflicts
   cancel-in-progress: true
 
 jobs:
   auto-assign:
-    name: Auto Assign
-    runs-on: ubuntu-latest
-
-    permissions:
-      issues: write # to be able to comment on released issues
-      pull-requests: write # to be able to comment on released pull requests
-
-    steps:
-      - name: "Auto-assign issue"
-        uses: pozil/auto-assign-issue@v2
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          assignees: fermeridamagni
-          numOfAssignee: 1
+    # Restrict workflow execution to repositories owned by 'magnidev'.
+    # This is intentional for internal use. Forks or external contributions will not execute this workflow.
+    if: github.repository_owner == 'magnidev'
+    name: Auto Assign Issue or PR
+    uses: magnidev/automation/.github/workflows/auto-assign.yml@main
+    with:
+      assignees: "fermeridamagni"
+      numOfAssignee: 1
+    secrets:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,9 +8,8 @@ on:
     branches:
       - main # Run on pull requests targeting the main branch
 
-# Automatically cancel in-progress actions on the same branch
 concurrency:
-  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }} # Group runs by workflow name and pull request number or branch ref
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }} # Cancel in-progress runs for branches other than main
 
 jobs:
@@ -22,7 +21,6 @@ jobs:
     secrets:
       BOT_APP_ID: ${{ secrets.BOT_APP_ID }}
       BOT_PRIVATE_KEY: ${{ secrets.BOT_PRIVATE_KEY }}
-
     with:
       commands: >
         [
@@ -31,4 +29,3 @@ jobs:
           "build",
           "test"
         ]
-      # The 'commands' input specifies the commands to run in the CI workflow.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ jobs:
     # Restrict workflow execution to repositories owned by 'magnidev'.
     # This is intentional for internal use. Forks or external contributions will not execute this workflow.
     if: github.repository_owner == 'magnidev'
+    name: Run CI Scripts
     uses: magnidev/automation/.github/workflows/run.yml@main # Reuse the run workflow from the magnidev/automation repository
     secrets:
       BOT_APP_ID: ${{ secrets.BOT_APP_ID }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     # Restrict workflow execution to repositories owned by 'magnidev'.
     # This is intentional for internal use. Forks or external contributions will not execute this workflow.
     if: github.repository_owner == 'magnidev'
-    name: Run CI Scripts
+    name: Scripts
     uses: magnidev/automation/.github/workflows/run.yml@main # Reuse the run workflow from the magnidev/automation repository
     secrets:
       BOT_APP_ID: ${{ secrets.BOT_APP_ID }}

--- a/.github/workflows/preview-package.yml
+++ b/.github/workflows/preview-package.yml
@@ -1,7 +1,11 @@
 name: preview package
 
 on:
-  workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "packages/**"
 
 jobs:
   preview:
@@ -13,4 +17,4 @@ jobs:
       bot_app_id: ${{ secrets.bot_app_id }}
       bot_private_key: ${{ secrets.bot_private_key }}
     with:
-      publish_directory: "./packages/*"
+      publish_directories: "./packages/*"

--- a/.github/workflows/preview-package.yml
+++ b/.github/workflows/preview-package.yml
@@ -1,9 +1,6 @@
 name: preview package
 
 on:
-  pull_request:
-    branches:
-      - main # run on pull requests targeting the main branch
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/preview-package.yml
+++ b/.github/workflows/preview-package.yml
@@ -1,0 +1,19 @@
+name: preview package
+
+on:
+  pull_request:
+    branches:
+      - main # run on pull requests targeting the main branch
+  workflow_dispatch:
+
+jobs:
+  preview:
+    # restrict workflow execution to repositories owned by 'magnidev'.
+    # this is intentional for internal use. forks or external contributions will not execute this workflow.
+    if: github.repository_owner == 'magnidev'
+    uses: magnidev/automation/.github/workflows/preview-package.yml@main
+    secrets:
+      bot_app_id: ${{ secrets.bot_app_id }}
+      bot_private_key: ${{ secrets.bot_private_key }}
+    with:
+      publish_directory: "./packages/*"


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow configuration to use a newer version of the `auto-assign-issue` action.

* [`.github/workflows/auto-assign.yml`](diffhunk://#diff-3df58dd42b351a284a19d2c3d3fe8c50db1cc811bb690ebbf402d1282bce9757L25-R25): Updated the `auto-assign-issue` action from version `v1` to `v2` to ensure compatibility with the latest features and improvements.