### PR TITLE
fix: update support contact email in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,6 @@ This project is licensed under the MIT License. See the [LICENSE](https://github
 
 ## 💬 Questions & Support
 
-For help, open an issue, start a discussion in the repository or contact us directly at [support@magni.dev](mailto:support@magni.dev).
+For help, open an issue, start a discussion in the repository or contact us directly at [contact@magni.dev](mailto:contact@magni.dev).
 
 ---


### PR DESCRIPTION
This pull request includes a minor change to the `README.md` file. The contact email for support has been updated from `support@magni.dev` to `contact@magni.dev`.