### PR TITLE
fix: add permissions section for auto-assign workflow

### DIFF
--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -11,6 +11,11 @@ concurrency:
   group: auto-assign-${{ github.ref }} # Group runs by the current ref to avoid conflicts
   cancel-in-progress: true
 
+permissions:
+  issues: write
+  pull-requests: write
+  contents: read
+
 jobs:
   auto-assign:
     # Restrict workflow execution to repositories owned by 'magnidev'.

--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -11,20 +11,19 @@ concurrency:
   group: auto-assign-${{ github.ref }} # Group runs by the current ref to avoid conflicts
   cancel-in-progress: true
 
-permissions:
-  issues: write
-  pull-requests: write
-  contents: read
-
 jobs:
   auto-assign:
-    # Restrict workflow execution to repositories owned by 'magnidev'.
-    # This is intentional for internal use. Forks or external contributions will not execute this workflow.
-    if: github.repository_owner == 'magnidev'
-    name: Auto Assign Issue or PR
-    uses: magnidev/automation/.github/workflows/auto-assign.yml@main
-    with:
-      assignees: "fermeridamagni"
-      numOfAssignee: 1
-    secrets:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    name: Auto Assign
+    runs-on: ubuntu-latest
+
+    permissions:
+      issues: write # to be able to comment on released issues
+      pull-requests: write # to be able to comment on released pull requests
+
+    steps:
+      - name: "Auto-assign issue"
+        uses: pozil/auto-assign-issue@v2
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          assignees: fermeridamagni
+          numOfAssignee: 1


### PR DESCRIPTION
This pull request updates the `.github/workflows/auto-assign.yml` file to enhance permissions for the workflow. The changes ensure that the workflow has the necessary access to manage issues, pull requests, and repository contents.

Permissions update:

* [`.github/workflows/auto-assign.yml`](diffhunk://#diff-3df58dd42b351a284a19d2c3d3fe8c50db1cc811bb690ebbf402d1282bce9757R14-R18): Added permissions for `issues: write`, `pull-requests: write`, and `contents: read` to enable the workflow to interact with issues, pull requests, and repository contents effectively.