### PR TITLE
fix: update sidebar color variables to use theme colors

### DIFF
--- a/packages/theme/src/tailwindcss/styles.css
+++ b/packages/theme/src/tailwindcss/styles.css
@@ -76,14 +76,14 @@
     --chart-3: oklch(0.398 0.07 227.392);
     --chart-4: oklch(0.828 0.189 84.429);
     --chart-5: oklch(0.769 0.188 70.08);
-    --sidebar: oklch(0.985 0 0);
-    --sidebar-foreground: oklch(0.145 0 0);
-    --sidebar-primary: oklch(0.205 0 0);
-    --sidebar-primary-foreground: oklch(1 0 0);
-    --sidebar-accent: oklch(0.97 0 0);
-    --sidebar-accent-foreground: oklch(0.205 0 0);
-    --sidebar-border: oklch(0.922 0 0);
-    --sidebar-ring: oklch(0.708 0 0);
+    --sidebar: var(--card);
+    --sidebar-foreground: var(--card-foreground);
+    --sidebar-primary: var(--primary);
+    --sidebar-primary-foreground: var(--primary-foreground);
+    --sidebar-accent: var(--accent);
+    --sidebar-accent-foreground: var(--accent-foreground);
+    --sidebar-border: var(--border);
+    --sidebar-ring: var(--ring);
   }
 
   .dark {
@@ -114,14 +114,14 @@
     --chart-3: oklch(0.769 0.188 70.08);
     --chart-4: oklch(0.627 0.265 303.9);
     --chart-5: oklch(0.645 0.246 16.439);
-    --sidebar: oklch(0.205 0 0);
-    --sidebar-foreground: oklch(1 0 0);
-    --sidebar-primary: oklch(0.488 0.243 264.376);
-    --sidebar-primary-foreground: oklch(1 0 0);
-    --sidebar-accent: oklch(0.269 0 0);
-    --sidebar-accent-foreground: oklch(1 0 0);
-    --sidebar-border: oklch(1 0 0 / 10%);
-    --sidebar-ring: oklch(0.556 0 0);
+    --sidebar: var(--card);
+    --sidebar-foreground: var(--card-foreground);
+    --sidebar-primary: var(--primary);
+    --sidebar-primary-foreground: var(--primary-foreground);
+    --sidebar-accent: var(--accent);
+    --sidebar-accent-foreground: var(--accent-foreground);
+    --sidebar-border: var(--border);
+    --sidebar-ring: var(--ring);
   }
 
   * {


### PR DESCRIPTION
This pull request updates the `styles.css` file in the `packages/theme/src/tailwindcss` directory to standardize the sidebar color variables by replacing hardcoded `oklch` values with references to existing CSS variables. This change improves maintainability and consistency across the theme.

### Standardization of sidebar color variables:

* Replaced hardcoded `oklch` values for `--sidebar`, `--sidebar-foreground`, `--sidebar-primary`, `--sidebar-primary-foreground`, `--sidebar-accent`, `--sidebar-accent-foreground`, `--sidebar-border`, and `--sidebar-ring` with corresponding CSS variables like `--card`, `--primary`, `--accent`, etc., in the light theme. (`[packages/theme/src/tailwindcss/styles.cssL79-R86](diffhunk://#diff-f91fcb00bbb01a56365819b13628b24a586c8a861b4801ce59e6169b586c5eb3L79-R86)`)
* Applied the same replacements for the dark theme to ensure consistent behavior across both themes. (`[packages/theme/src/tailwindcss/styles.cssL117-R124](diffhunk://#diff-f91fcb00bbb01a56365819b13628b24a586c8a861b4801ce59e6169b586c5eb3L117-R124)`)