### PR TITLE
fix: bump version to 0.3.1 in package.json

### DIFF
--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@magnidev/theme",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "license": "ISC",
   "description": "Theme for Magni Development.",
   "author": {


### PR DESCRIPTION
This pull request includes a version bump for the `@magnidev/theme` package. The version has been updated from `0.3.0` to `0.3.1` to reflect minor changes or patches.