### PR TITLE
chore: update version to 2.0.0-canary.2 in package.json

### DIFF
--- a/packages/repo-cli/package.json
+++ b/packages/repo-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@magnidev/repo-cli",
-  "version": "2.0.0-canary.1",
+  "version": "2.0.0-canary.2",
   "type": "commonjs",
   "license": "ISC",
   "description": "CLI to manage packages in Repositories or Monorepos of GitHub.",


### PR DESCRIPTION
This pull request includes a small version bump in the `packages/repo-cli/package.json` file. The version was updated from `2.0.0-canary.1` to `2.0.0-canary.2` to reflect a new release.