### PR TITLE
Feat/add readme for react hooks package

### DIFF
--- a/packages/react-hooks/LICENSE
+++ b/packages/react-hooks/LICENSE
@@ -1,0 +1,21 @@
+# MIT License
+
+Copyright (c) 2025 Magni Developer
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/react-hooks/README.md
+++ b/packages/react-hooks/README.md
@@ -1,0 +1,76 @@
+# @magnidev/react-hooks
+
+A collection of reusable React hooks for modern web development, designed to simplify state management, validation, and other common patterns in React applications.
+
+## Features
+
+- **Validation hooks**: Easily validate user input for forms (email, password, username, etc.)
+- **Schema utilities**: Predefined schemas for authentication and more
+- **Utility functions**: Helpers for common React patterns
+
+## Installation
+
+Using [pnpm](https://pnpm.io/):
+
+```bash
+pnpm add @magnidev/react-hooks
+```
+
+Or with npm:
+
+```bash
+npm install @magnidev/react-hooks
+```
+
+Or with yarn:
+
+```bash
+yarn add @magnidev/react-hooks
+```
+
+## Usage
+
+Import the hooks you need:
+
+```tsx
+import { useState } from "react";
+import { useValidateEmail, useValidatePassword } from "@magnidev/react-hooks";
+
+function MyForm() {
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+
+  const validateEmail = useValidateEmail(email);
+  const validatePassword = useValidatePassword(password);
+
+  if (!validateEmail.isValid) {
+    console.error(validateEmail.error);
+  }
+
+  if (!validatePassword.isValid) {
+    console.error(validatePassword.error);
+  }
+
+  // ...
+}
+```
+
+## Available Hooks
+
+- `useValidateEmail` for validating email addresses
+- `useValidatePassword` for validating passwords
+- `useValidateUsername` for validating usernames
+- `useValidateName` for validating names
+- `useValidateText` for validating general text input
+
+## Schemas
+
+- `authSchema` for authentication-related validation
+
+## Contributing
+
+Contributions are welcome! Please see [contributing](../../CONTRIBUTING.md) for guidelines.
+
+## License
+
+This project is licensed under the MIT License - see the [LICENSE](LICENSE)[LICENSE](LICENSE) file for details.

--- a/packages/react-hooks/README.md
+++ b/packages/react-hooks/README.md
@@ -73,4 +73,4 @@ Contributions are welcome! Please see [contributing](../../CONTRIBUTING.md) for 
 
 ## License
 
-This project is licensed under the MIT License - see the [LICENSE](LICENSE)[LICENSE](LICENSE) file for details.
+This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.

--- a/packages/react-hooks/package.json
+++ b/packages/react-hooks/package.json
@@ -2,7 +2,12 @@
   "name": "@magnidev/react-hooks",
   "version": "1.0.0",
   "description": "",
-  "keywords": [],
+  "keywords": [
+    "react",
+    "hooks",
+    "validation",
+    "magnidev"
+  ],
   "author": {
     "name": "fermeridamagni <Magni Development>",
     "email": "hello@magni.dev",
@@ -35,7 +40,11 @@
     }
   },
   "files": [
-    "dist"
+    "dist",
+    "package.json",
+    "README.md",
+    "LICENSE",
+    "CHANGELOG.md"
   ],
   "scripts": {
     "build": "unbuild",


### PR DESCRIPTION
This pull request introduces a new package, `@magnidev/react-hooks`, which provides reusable React hooks for common web development patterns. Key changes include the addition of licensing information, documentation, and updates to the package metadata to prepare it for publication.

### Licensing and Documentation:

- Added an MIT license to the repository in the `LICENSE` file, specifying terms for usage, distribution, and liability. (`packages/react-hooks/LICENSE`, [packages/react-hooks/LICENSER1-R21](diffhunk://#diff-757d9961f7ab0732848bf058b19188e8e22a558968e84c99cfa87c8d6af0ba38R1-R21))
- Created a comprehensive `README.md` file describing the package's purpose, features, installation instructions, usage examples, and available hooks. (`packages/react-hooks/README.md`, [packages/react-hooks/README.mdR1-R76](diffhunk://#diff-bd9dc131cf11e4e43d8ee5916194da73f7b061b7305043c849175f9b034f2e33R1-R76))

### Package Metadata:

- Updated `package.json` to include relevant keywords (`react`, `hooks`, `validation`, `magnidev`) to improve discoverability. (`packages/react-hooks/package.json`, [packages/react-hooks/package.jsonL5-R10](diffhunk://#diff-299f29a7098fc18c8f8c08cbdee21d557ee8250c962a95e4200d035003834f0cL5-R10))
- Expanded the `files` field in `package.json` to include essential files (`package.json`, `README.md`, `LICENSE`, `CHANGELOG.md`) for distribution. (`packages/react-hooks/package.json`, [packages/react-hooks/package.jsonL38-R47](diffhunk://#diff-299f29a7098fc18c8f8c08cbdee21d557ee8250c962a95e4200d035003834f0cL38-R47))